### PR TITLE
GP-6: remove redundant public accessor in test methods declaration

### DIFF
--- a/account-dao/src/test/java/com/bobocode/dao/AccountDaoTest.java
+++ b/account-dao/src/test/java/com/bobocode/dao/AccountDaoTest.java
@@ -20,7 +20,10 @@ import java.sql.Timestamp;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -142,7 +145,7 @@ class AccountDaoTest {
     }
 
     @Test
-    public void testRemoveAccount() {
+    void testRemoveAccount() {
         Account account = TestDataGenerator.generateAccount();
         saveTestAccount(account);
 
@@ -153,7 +156,7 @@ class AccountDaoTest {
     }
 
     @Test
-    public void testSaveInvalidAccount() {
+    void testSaveInvalidAccount() {
         try {
             Account invalidAccount = TestDataGenerator.generateAccount();
             invalidAccount.setEmail(null);
@@ -165,7 +168,7 @@ class AccountDaoTest {
     }
 
     @Test
-    public void testUpdateInvalidAccount() {
+    void testUpdateInvalidAccount() {
         try {
             Account account = TestDataGenerator.generateAccount();
             saveTestAccount(account);

--- a/company-products/src/test/java/com/bobocode/CompanyProductMappingTest.java
+++ b/company-products/src/test/java/com/bobocode/CompanyProductMappingTest.java
@@ -19,12 +19,14 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CompanyProductMappingTest {
+class CompanyProductMappingTest {
     private static EntityManagerUtil emUtil;
     private static EntityManagerFactory entityManagerFactory;
     private static CompanyDao companyDao;
@@ -42,7 +44,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testSaveCompany() {
+    void testSaveCompany() {
         var company = createRandomCompany();
         emUtil.performWithinTx(entityManager -> entityManager.persist(company));
 
@@ -56,7 +58,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testSaveProduct() {
+    void testSaveProduct() {
         var product = createRandomProduct();
 
         emUtil.performWithinTx(entityManager -> entityManager.persist(product));
@@ -69,7 +71,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testSaveCompanyWithNullName() {
+    void testSaveCompanyWithNullName() {
         var company = new Company();
 
         try {
@@ -81,7 +83,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testSaveProductWithNullName() {
+    void testSaveProductWithNullName() {
         var product = new Product();
 
         try {
@@ -93,7 +95,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testForeignKeyColumnIsSpecified() throws NoSuchFieldException {
+    void testForeignKeyColumnIsSpecified() throws NoSuchFieldException {
         Field company = Product.class.getDeclaredField("company");
         JoinColumn joinColumn = company.getAnnotation(JoinColumn.class);
 
@@ -101,7 +103,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testSaveProductAndCompany() {
+    void testSaveProductAndCompany() {
         var company = createRandomCompany();
         var product = createRandomProduct();
 
@@ -121,7 +123,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testAddNewProductToExistingCompany() {
+    void testAddNewProductToExistingCompany() {
         var company = createRandomCompany();
         emUtil.performWithinTx(entityManager -> entityManager.persist(company));
 
@@ -130,7 +132,7 @@ public class CompanyProductMappingTest {
             entityManager.persist(product);
             var managedCompany = entityManager.merge(company);
             managedCompany.addProduct(product);
-            assertThat(managedCompany.getProducts(),hasItem(product));
+            assertThat(managedCompany.getProducts(), hasItem(product));
         });
 
         assertThat(product.getCompany(), equalTo(company));
@@ -142,7 +144,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testRemoveProductFromCompany() {
+    void testRemoveProductFromCompany() {
         var company = createRandomCompany();
         emUtil.performWithinTx(entityManager -> entityManager.persist(company));
 
@@ -166,7 +168,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testCompanyToProductsIsLazy() {
+    void testCompanyToProductsIsLazy() {
         var company = createRandomCompany();
         emUtil.performWithinTx(entityManager -> entityManager.persist(company));
 
@@ -187,7 +189,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testProductsToCompanyIsLazy() {
+    void testProductsToCompanyIsLazy() {
         var company = createRandomCompany();
         emUtil.performWithinTx(entityManager -> entityManager.persist(company));
 
@@ -208,7 +210,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testFindByIdFetchesProducts() {
+    void testFindByIdFetchesProducts() {
         var company = createRandomCompany();
         emUtil.performWithinTx(entityManager -> entityManager.persist(company));
 
@@ -224,7 +226,7 @@ public class CompanyProductMappingTest {
     }
 
     @Test
-    public void testCompanySetProductsIsPrivate() throws NoSuchMethodException {
+    void testCompanySetProductsIsPrivate() throws NoSuchMethodException {
         assertThat(Company.class.getDeclaredMethod("setProducts", List.class).getModifiers(), equalTo(Modifier.PRIVATE));
     }
 }

--- a/employee-profile/src/test/java/com/bobocode/EmployeeProfileMappingTest.java
+++ b/employee-profile/src/test/java/com/bobocode/EmployeeProfileMappingTest.java
@@ -8,9 +8,12 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import javax.persistence.*;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.JoinColumn;
+import javax.persistence.Persistence;
+import javax.persistence.PersistenceException;
+import javax.persistence.Table;
 import java.lang.reflect.Field;
-import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -18,7 +21,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class EmployeeProfileMappingTest {
+class EmployeeProfileMappingTest {
     private static EntityManagerUtil emUtil;
     private static EntityManagerFactory entityManagerFactory;
 
@@ -34,7 +37,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testSaveEmployeeOnly() {
+    void testSaveEmployeeOnly() {
         Employee employee = createRandomEmployee();
 
         emUtil.performWithinTx(entityManager -> entityManager.persist(employee));
@@ -51,7 +54,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testSaveEmployeeWithoutEmail() {
+    void testSaveEmployeeWithoutEmail() {
         Employee employee = createRandomEmployee();
         employee.setEmail(null);
         try {
@@ -63,7 +66,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testSaveEmployeeFirstName() {
+    void testSaveEmployeeFirstName() {
         Employee employee = createRandomEmployee();
         employee.setFistName(null);
         try {
@@ -75,7 +78,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testSaveEmployeeLastName() {
+    void testSaveEmployeeLastName() {
         Employee employee = createRandomEmployee();
         employee.setLastName(null);
         try {
@@ -87,7 +90,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testSaveEmployeeProfileOnly() {
+    void testSaveEmployeeProfileOnly() {
         EmployeeProfile employeeProfile = createRandomEmployeeProfile();
         employeeProfile.setId(666L);
 
@@ -107,7 +110,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testSaveBothEmployeeAndEmployeeProfile() {
+    void testSaveBothEmployeeAndEmployeeProfile() {
         Employee employee = createRandomEmployee();
         EmployeeProfile employeeProfile = createRandomEmployeeProfile();
 
@@ -123,7 +126,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testAddEmployeeProfile() {
+    void testAddEmployeeProfile() {
         Employee employee = createRandomEmployee();
         emUtil.performWithinTx(entityManager -> entityManager.persist(employee));
         long employeeId = employee.getId();
@@ -141,7 +144,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testAddEmployeeWithoutPosition() {
+    void testAddEmployeeWithoutPosition() {
         Employee employee = createRandomEmployee();
         emUtil.performWithinTx(entityManager -> entityManager.persist(employee));
         long employeeId = employee.getId();
@@ -161,7 +164,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testAddEmployeeWithoutDepartment() {
+    void testAddEmployeeWithoutDepartment() {
         Employee employee = createRandomEmployee();
         emUtil.performWithinTx(entityManager -> entityManager.persist(employee));
         long employeeId = employee.getId();
@@ -181,7 +184,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testForeignKeyColumnHasCorrectName() throws NoSuchFieldException {
+    void testForeignKeyColumnHasCorrectName() throws NoSuchFieldException {
         Field employee = EmployeeProfile.class.getDeclaredField("employee");
         JoinColumn joinColumn = employee.getAnnotation(JoinColumn.class);
         String foreignKeyColumnName = joinColumn.name();
@@ -190,7 +193,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testEmployeeTableHasCorrectName() {
+    void testEmployeeTableHasCorrectName() {
         Table table = Employee.class.getAnnotation(Table.class);
         String tableName = table.name();
 
@@ -198,7 +201,7 @@ public class EmployeeProfileMappingTest {
     }
 
     @Test
-    public void testEmployeeProfileTableHasCorrectName() {
+    void testEmployeeProfileTableHasCorrectName() {
         Table table = EmployeeProfile.class.getAnnotation(Table.class);
         String tableName = table.name();
 


### PR DESCRIPTION
Remove redundant public accessor in test methods declaration and exclude usage of "*" in imports